### PR TITLE
Add Issue and PR templates.

### DIFF
--- a/.github/ISSUE_TEMPLATES/bug_report.md
+++ b/.github/ISSUE_TEMPLATES/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve our program.
+title: "[BUG]"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here, such as OS, software version, configuration.

--- a/.github/ISSUE_TEMPLATES/config.yml
+++ b/.github/ISSUE_TEMPLATES/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATES/feature_request.md
+++ b/.github/ISSUE_TEMPLATES/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for a custom command
+title: "[REQUEST]"
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+You can link issues and PRs here, and also elaborate on a problem you run into,
+such as unreadable fonts, unclear descriptions.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen;  
+if applicable, conceptual screenshots are appreciated.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATES/feature_request.md
+++ b/.github/ISSUE_TEMPLATES/feature_request.md
@@ -8,8 +8,8 @@ assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
-You can link issues and PRs here, and also elaborate on a problem you run into,
-such as unreadable fonts, unclear descriptions.
+Link Issues and PRs here, if applicable.
+Further, suggestions such as removing unreadable fonts and fixing unclear descriptions are fine, as well.
 
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen;  

--- a/.github/ISSUE_TEMPLATES/general_question.md
+++ b/.github/ISSUE_TEMPLATES/general_question.md
@@ -7,5 +7,5 @@ assignees: ''
 ---
 
 **What is your question?**
-Elaborate on your question as precisely as possible, such as
-"How do I do...", "When are you going to add..."
+Elaborate on your question as precisely as possible.
+Please make sure that your question does not fit into either a bug report or a feature request.

--- a/.github/ISSUE_TEMPLATES/general_question.md
+++ b/.github/ISSUE_TEMPLATES/general_question.md
@@ -1,0 +1,11 @@
+---
+name: General Question
+about: A general question, no bug reports or requests here.
+labels: question
+assignees: ''
+
+---
+
+**What is your question?**
+Elaborate on your question as precisely as possible, such as
+"How do I do...", "When are you going to add..."

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,8 @@
 Explain is one or two sentences what you did.
 
 **Explanation**
-Elaborate on your additions, is documentation required? Did you fix any issues (link them using #ISSUE-NUMBER)?
-Does the program run faster, any other optimizations? Creation of graphic assets?
+What did you add? Link possible issues you fixed.
+Elaborate if documentation is needed, the maintainers will then take care of it.
 
 If applicable, post screenshots.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+**Summary**
+Explain is one or two sentences what you did.
+
+**Explanation**
+Elaborate on your additions, is documentation required? Did you fix any issues (link them using #ISSUE-NUMBER)?
+Does the program run faster, any other optimizations? Creation of graphic assets?
+
+If applicable, post screenshots.
+
+---
+**Status**
+*Apart from the GitHub action ran automatically on your PR, please confirm the following:**
+
+- [] code changes have been tested using appropiate testing methods, or there are no code changes.


### PR DESCRIPTION
This pull request adds GitHub issue and PR templates.

These templates will allow for a more concise and thorough workflow.
Just a further step to organize the repository before going into the "real coding".

Thanks : )